### PR TITLE
Trim program.name and displayName in ProgramFormComponent

### DIFF
--- a/packages/openchs-android/src/views/program/ProgramFormComponent.js
+++ b/packages/openchs-android/src/views/program/ProgramFormComponent.js
@@ -41,7 +41,9 @@ class ProgramFormComponent extends AbstractComponent {
     }
 
     getNextParams(popVerificationVew) {
-       
+        state.enrolment.program.name = state.enrolment.program.name.trim();
+        state.enrolment.program.displayName = state.enrolment.program.displayName.trim();
+
         const observations = this.props.context.usage === ProgramEnrolmentState.UsageKeys.Enrol ? this.props.state.enrolment.observations : this.props.state.enrolment.programExitObservations;
         const phoneNumberObservation = _.find(observations, obs => obs.isPhoneNumberVerificationRequired(this.props.state.filteredFormElements));
         return {


### PR DESCRIPTION
This pull request ensures that both program.name and program.displayName are trimmed (i.e., any leading/trailing whitespace is removed) before they are used in the ProgramFormComponent.